### PR TITLE
Include Radio Jambo data for e03

### DIFF
--- a/configuration/pipeline_config.json
+++ b/configuration/pipeline_config.json
@@ -4,6 +4,22 @@
     {
       "SourceType": "RapidPro",
       "Domain": "textit.in",
+      "TokenFileURL": "gs://avf-credentials/covid19-text-it-token.txt",
+      "ContactsFileName": "covid19_contacts",
+      "ActivationFlowNames": [
+        "covid19_s01e03_activation"
+      ],
+      "SurveyFlowNames": [
+        "covid19_s01_demog"
+      ],
+      "TestContactUUIDs": [
+        "eed078e5-7d13-4f3c-ac93-8b477125b31d",
+        "67836f40-a155-4757-850c-b407bd1cd475"
+      ]
+    },
+    {
+      "SourceType": "RapidPro",
+      "Domain": "textit.in",
       "TokenFileURL": "gs://avf-credentials/covid19-2-text-it-token.txt",
       "ContactsFileName": "covid19_2_contacts",
       "ActivationFlowNames": [
@@ -38,6 +54,20 @@
     {"RapidProKey": "Rqa_S01E03 (Text) - covid19_ke_urban_s01e03_activation", "PipelineKey": "rqa_s01e03_raw", "IsActivationMessage": true},
     {"RapidProKey": "Rqa_S01E03 (Run ID) - covid19_ke_urban_s01e03_activation", "PipelineKey": "rqa_s01e03_run_id"},
     {"RapidProKey": "Rqa_S01E03 (Time) - covid19_ke_urban_s01e03_activation", "PipelineKey": "sent_on"},
+
+    {"RapidProKey": "Rqa_S01E02 (Text) - covid19_s01e03_activation", "PipelineKey": "rqa_s01e03_raw", "IsActivationMessage": true},
+    {"RapidProKey": "Rqa_S01E02 (Run ID) - covid19_s01e03_activation", "PipelineKey": "rqa_s01e03_run_id"},
+    {"RapidProKey": "Rqa_S01E02 (Time) - covid19_s01e03_activation", "PipelineKey": "sent_on"},
+    {"RapidProKey": "Rqa_S01E03 (Text) - covid19_s01e03_activation", "PipelineKey": "rqa_s01e03_raw", "IsActivationMessage": true},
+    {"RapidProKey": "Rqa_S01E03 (Run ID) - covid19_s01e03_activation", "PipelineKey": "rqa_s01e03_run_id"},
+    {"RapidProKey": "Rqa_S01E03 (Time) - covid19_s01e03_activation", "PipelineKey": "sent_on"},
+
+    {"RapidProKey": "Constituency (Text) - covid19_s01_demog", "PipelineKey": "location_raw"},
+    {"RapidProKey": "Constituency (Time) - covid19_s01_demog", "PipelineKey": "location_time"},
+    {"RapidProKey": "Gender (Text) - covid19_s01_demog", "PipelineKey": "gender_raw"},
+    {"RapidProKey": "Gender (Time) - covid19_s01_demog", "PipelineKey": "gender_time"},
+    {"RapidProKey": "Age (Text) - covid19_s01_demog", "PipelineKey": "age_raw"},
+    {"RapidProKey": "Age (Time) - covid19_s01_demog", "PipelineKey": "age_time"},
 
     {"RapidProKey": "Constituency (Text) - covid19_ke_urban_s01_demog", "PipelineKey": "location_raw"},
     {"RapidProKey": "Constituency (Time) - covid19_ke_urban_s01_demog", "PipelineKey": "location_time"},


### PR DESCRIPTION
Just to explain what’s going on: We ran 4 weeks of shows on Radio Jambo (COVID19) with limited control over the content, so asked the same question each week. That project has now come to an end. Separately, we were running a project targeting urban poor (COVID19-KE-Urban) on Ghetto Radio, which is continuing. However, we now have funding to control the content on Jambo, so we’re harmonising the content between the two stations. This can be thought of as effectively taking KE-Urban nationwide, so we only need one dataset in Coda (same question, same coding frame) and one analysis file, which in future may be tagged with the shortcode each message was received on. We’re still maintaining the two shortcodes, because of the risk to engagement of trying to change the codes now, and because of the risk to analysis of not being able to separate the radio stations in future should we need to, but are now pulling the data from both instances into this pipeline. That’s why you see the configuration file updated to refer to both instances. 

For the most part this “just works”, even if people respond to the RQA on both shortcodes. The main exception is demogs, where if people answer both we’ll only look at the answers from one. The overlap is currently very low (5 common numbers after 4000 vs. 300 participants on jambo/ghetto so far), and we have alternative strategies like concatenate or TextIt contact fields sync available if needed.

One final piece of complexity: we switched to the covid19_s01e02 activation flow before taking the decision to harmonise the projects. We then renamed this to s01e03, but there are still some runs with the old terminology, which is why you see the remapping from “Rqa_S01E02 (Text) - covid19_s01e03_activation”.

TL;DR: COVID19-KE-Urban is now running on Ghetto and Jambo but on different shortcodes. This PR pulls the newest Jambo data into the KE-Urban pipeline too.