### PR TITLE
Tag data with the source instance name (Jambo or Ghetto)

### DIFF
--- a/code_schemes/source.json
+++ b/code_schemes/source.json
@@ -1,0 +1,69 @@
+{
+  "SchemeID": "Scheme-f0ecdb96",
+  "Name": "Source",
+  "Version": "0.0.0.1",
+  "Codes": [
+    {
+      "CodeID": "code-6bce26f0",
+      "CodeType": "Normal",
+      "DisplayText": "jambo",
+      "NumericValue": 1,
+      "StringValue": "jambo",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "jambo",
+        "Jambo"
+      ]
+    },
+    {
+      "CodeID": "code-36857718",
+      "CodeType": "Normal",
+      "DisplayText": "ghetto",
+      "NumericValue": 2,
+      "StringValue": "ghetto",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "ghetto",
+        "Ghetto"
+      ]
+    },
+    {
+      "CodeID": "code-629c6be7",
+      "CodeType": "Normal",
+      "DisplayText": "both",
+      "NumericValue": 3,
+      "StringValue": "both",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "both"
+      ]
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": false
+    }
+  ]
+}

--- a/configuration/code_schemes.py
+++ b/configuration/code_schemes.py
@@ -17,6 +17,8 @@ class CodeSchemes(object):
     S01E03 = _open_scheme("s01e03.json")
     S01E04 = _open_scheme("s01e04.json")
 
+    SOURCE = _open_scheme("source.json")
+
     KENYA_CONSTITUENCY = _open_scheme("kenya_constituency.json")
     KENYA_COUNTY = _open_scheme("kenya_county.json")
     GENDER = _open_scheme("gender.json")

--- a/configuration/coding_plans.py
+++ b/configuration/coding_plans.py
@@ -1,4 +1,6 @@
 from core_data_modules.cleaners import somali, swahili, Codes
+from core_data_modules.cleaners.cleaning_utils import CleaningUtils
+from core_data_modules.traced_data import Metadata
 from core_data_modules.traced_data.util.fold_traced_data import FoldStrategies
 
 from configuration import code_imputation_functions
@@ -108,8 +110,29 @@ def get_rqa_coding_plans(pipeline_name):
     ]
 
 
+def fold_source(x, y):
+    if x["CodeID"] == y["CodeID"]:
+        return x
+    else:
+        return CleaningUtils.make_label_from_cleaner_code(
+            CodeSchemes.SOURCE, CodeSchemes.SOURCE.get_code_with_match_value("both"), Metadata.get_call_location()
+        )
+
+
 def get_survey_coding_plans(pipeline_name):
     return [
+        CodingPlan(raw_field="source_raw",
+                   coding_configurations=[
+                       CodingConfiguration(
+                           coding_mode=CodingModes.SINGLE,
+                           code_scheme=CodeSchemes.SOURCE,
+                           coded_field="source_coded",
+                           analysis_file_key="source",
+                           fold_strategy=fold_source
+                       )
+                   ],
+                   raw_field_fold_strategy=FoldStrategies.concatenate),
+
         CodingPlan(raw_field="gender_raw",
                    time_field="gender_time",
                    coda_filename="COVID19_gender.json",

--- a/configuration/pipeline_config.json
+++ b/configuration/pipeline_config.json
@@ -3,6 +3,7 @@
   "RawDataSources": [
     {
       "SourceType": "RapidPro",
+      "SourceName": "Jambo",
       "Domain": "textit.in",
       "TokenFileURL": "gs://avf-credentials/covid19-text-it-token.txt",
       "ContactsFileName": "covid19_contacts",
@@ -21,6 +22,7 @@
     },
     {
       "SourceType": "RapidPro",
+      "SourceName": "Ghetto",
       "Domain": "textit.in",
       "TokenFileURL": "gs://avf-credentials/covid19-2-text-it-token.txt",
       "ContactsFileName": "covid19_2_contacts",

--- a/src/lib/pipeline_configuration.py
+++ b/src/lib/pipeline_configuration.py
@@ -65,7 +65,7 @@ class PipelineConfiguration(object):
         # TODO: This is a temporary COVID19-specific hack to extract demographics out of the surveys, so that the
         #       automated analysis can analyse demographics only. Not fixing this properly here for now, because we may
         #       instead decide to analysis all of the survey questions in the same way as we do the demographics.
-        PipelineConfiguration.DEMOG_CODING_PLANS = coding_plans.get_survey_coding_plans(self.pipeline_name)[0:3]
+        PipelineConfiguration.DEMOG_CODING_PLANS = PipelineConfiguration.SURVEY_CODING_PLANS
         PipelineConfiguration.WS_CORRECT_DATASET_SCHEME = coding_plans.get_ws_correct_dataset_scheme(self.pipeline_name)
 
         self.validate()
@@ -165,8 +165,8 @@ class RawDataSource(ABC):
 
 
 class RapidProSource(RawDataSource):
-    def __init__(self, domain, token_file_url, contacts_file_name, activation_flow_names, survey_flow_names,
-                 test_contact_uuids):
+    def __init__(self, source_name, domain, token_file_url, contacts_file_name, activation_flow_names,
+                 survey_flow_names, test_contact_uuids):
         """
         :param domain: URL of the Rapid Pro server to download data from.
         :type domain: str
@@ -183,6 +183,7 @@ class RapidProSource(RawDataSource):
                                    and dropped when the pipeline is run with "FilterTestMessages" set to true.
         :type test_contact_uuids: list of str
         """
+        self.source_name = source_name
         self.domain = domain
         self.token_file_url = token_file_url
         self.contacts_file_name = contacts_file_name
@@ -200,6 +201,7 @@ class RapidProSource(RawDataSource):
 
     @classmethod
     def from_configuration_dict(cls, configuration_dict):
+        source_name = configuration_dict["SourceName"]
         domain = configuration_dict["Domain"]
         token_file_url = configuration_dict["TokenFileURL"]
         contacts_file_name = configuration_dict["ContactsFileName"]
@@ -207,10 +209,11 @@ class RapidProSource(RawDataSource):
         survey_flow_names = configuration_dict.get("SurveyFlowNames", [])
         test_contact_uuids = configuration_dict.get("TestContactUUIDs", [])
 
-        return cls(domain, token_file_url, contacts_file_name, activation_flow_names,
+        return cls(source_name, domain, token_file_url, contacts_file_name, activation_flow_names,
                    survey_flow_names, test_contact_uuids)
 
     def validate(self):
+        validators.validate_string(self.source_name, "source_name")
         validators.validate_string(self.domain, "domain")
         validators.validate_string(self.token_file_url, "token_file_url")
         validators.validate_string(self.contacts_file_name, "contacts_file_name")


### PR DESCRIPTION
Labels with jambo/ghetto because I think this makes most sense to the rest of the team (cautious about using a shortcode because we have multiple channels connected, and reluctant to use instance names COVID19 and COVID19-2 because not everyone knows what those mean).

Classed as a demographic for now because we use the "source" to do the same kinds of splits for analysis as we would any other demographic. Concatenates source_raw in analysis (e.g. "Jambo;Jambo;Ghetto", which looks a bit weird but serves as a nice check that everything is working.