### PR TITLE
Add urban maps showing constituencies in Nairobi and Kiambu.

### DIFF
--- a/automated_analysis.py
+++ b/automated_analysis.py
@@ -402,9 +402,8 @@ if __name__ == "__main__":
 
     fig, ax = plt.subplots()
     MappingUtils.plot_frequency_map(nairobi_map, "ADM2_AVF", nairobi_frequencies, ax=ax,
-                                    labels=labels,
-                                    callout_position_columns=("ADM2_CALLX", "ADM2_CALLY"),
-                                    label_position_columns=("ADM2_LX", "ADM2_LY"))
+                                    labels=labels, label_position_columns=("ADM2_LX", "ADM2_LY"),
+                                    callout_position_columns=("ADM2_CALLX", "ADM2_CALLY"))
     fig.savefig(f"{output_dir}/maps/nairobi_total_participants.png", dpi=1200, bbox_inches="tight")
     plt.close(fig)
 

--- a/automated_analysis.py
+++ b/automated_analysis.py
@@ -403,6 +403,7 @@ if __name__ == "__main__":
     fig, ax = plt.subplots()
     MappingUtils.plot_frequency_map(nairobi_map, "ADM2_AVF", nairobi_frequencies, ax=ax,
                                     labels=labels,
+                                    callout_position_columns=("ADM2_CALLX", "ADM2_CALLY"),
                                     label_position_columns=("ADM2_LX", "ADM2_LY"))
     fig.savefig(f"{output_dir}/maps/nairobi_total_participants.png", dpi=1200, bbox_inches="tight")
     plt.close(fig)

--- a/automated_analysis.py
+++ b/automated_analysis.py
@@ -375,8 +375,13 @@ if __name__ == "__main__":
 
     log.info("Loading the Kenya constituency geojson...")
     constituencies_map = geopandas.read_file("geojson/kenya_constituencies.geojson")
-    # nairobi_map = constituencies_map[constituencies_map.ADM1_AVF.isin({KenyaCodes.NAIROBI, KenyaCodes.KIAMBU})]
-    nairobi_map = constituencies_map[constituencies_map.ADM1_AVF.isin({KenyaCodes.NAIROBI})]
+    nairobi_map = constituencies_map[constituencies_map.ADM1_AVF.isin({KenyaCodes.NAIROBI, KenyaCodes.KIAMBU})]
+    # Constituencies to label with their name, as requested by RDA for COVID19-KE-Urban
+    constituencies_to_name_label = {
+        # TODO: Switch to use KenyaCodes instead of strings
+        "kibra", "mathare", "embakasi_east", "embakasi_central", "kasarani",  # requested because urban-poor targets
+        "ruiru", "kikuyu", "kiambu"  # requested due to high participation
+    }
 
     constituency_display_names = dict()
     for i, admin_region in constituencies_map.iterrows():
@@ -388,8 +393,12 @@ if __name__ == "__main__":
     for code in CodeSchemes.KENYA_CONSTITUENCY.codes:
         if code.code_type == CodeTypes.NORMAL:
             nairobi_frequencies[code.string_value] = demographic_distributions["constituency"][code.string_value]
-            constituency_name = constituency_display_names[code.string_value]
-            labels[code.string_value] = constituency_name + "\n" + str(nairobi_frequencies[code.string_value])
+
+            if code.string_value in constituencies_to_name_label:
+                constituency_name = constituency_display_names[code.string_value]
+                labels[code.string_value] = constituency_name + "\n" + str(nairobi_frequencies[code.string_value])
+            else:
+                labels[code.string_value] = str(nairobi_frequencies[code.string_value])
 
     fig, ax = plt.subplots()
     MappingUtils.plot_frequency_map(nairobi_map, "ADM2_AVF", nairobi_frequencies, ax=ax,

--- a/automated_analysis.py
+++ b/automated_analysis.py
@@ -9,6 +9,7 @@ import geopandas
 import matplotlib.pyplot as plt
 import plotly.express as px
 from core_data_modules.cleaners import Codes
+from core_data_modules.cleaners.codes import KenyaCodes
 from core_data_modules.data_models.code_scheme import CodeTypes
 from core_data_modules.logging import Logger
 from core_data_modules.traced_data.io import TracedDataJsonIO
@@ -370,7 +371,25 @@ if __name__ == "__main__":
 
         for sample in samples:
             writer.writerow(sample)
-            
+
+    log.info("Loading the Kenya constituency geojson...")
+    constituencies_map = geopandas.read_file("geojson/kenya_constituencies.geojson")
+    nairobi_map = constituencies_map[constituencies_map.ADM1_AVF == KenyaCodes.NAIROBI]
+
+    log.info("Generating a map of participation in Nairobi for the season")
+    nairobi_frequencies = dict()
+    for code in CodeSchemes.KENYA_CONSTITUENCY.codes:
+        if code.code_type == CodeTypes.NORMAL:
+            nairobi_frequencies[code.string_value] = demographic_distributions["constituency"][code.string_value]
+
+    fig, ax = plt.subplots()
+    MappingUtils.plot_frequency_map(nairobi_map, "ADM2_AVF", nairobi_frequencies, ax=ax,
+                                    label_position_columns=("ADM2_LX", "ADM2_LY"))
+    fig.savefig(f"{output_dir}/maps/nairobi_total_participants.png", dpi=1200, bbox_inches="tight")
+    plt.close(fig)
+
+    exit(0)
+
     log.info("Loading the Kenya county geojson...")
     counties_map = geopandas.read_file("geojson/kenya_counties.geojson")
 

--- a/automated_analysis.py
+++ b/automated_analysis.py
@@ -421,31 +421,31 @@ if __name__ == "__main__":
             plt.close(fig)
 
             # Plot maps of each of the normal themes for this coding configuration.
-            # map_index = 2  # (index 1 was used in the total relevant map's filename).
-            # for code in cc.code_scheme.codes:
-            #     if code.code_type != CodeTypes.NORMAL:
-            #         continue
-            #
-            #     theme = f"{cc.analysis_file_key}{code.string_value}"
-            #     log.info(f"Generating a map of per-county participation for {theme}...")
-            #     demographic_counts = episode[theme]
-            #
-            #     theme_county_frequencies = dict()
-            #     for county_code in CodeSchemes.KENYA_COUNTY.codes:
-            #         if county_code.code_type == CodeTypes.NORMAL:
-            #             theme_county_frequencies[county_code.string_value] = \
-            #                 demographic_counts[f"county:{county_code.string_value}"]
-            #
-            #     fig, ax = plt.subplots()
-            #     MappingUtils.plot_frequency_map(counties_map, "ADM1_AVF", theme_county_frequencies, ax=ax,
-            #                                     label_position_columns=("ADM1_LX", "ADM1_LY"),
-            #                                     callout_position_columns=("ADM1_CALLX", "ADM1_CALLY"))
-            #     MappingUtils.plot_water_bodies(lakes_map, ax=ax)
-            #     fig.savefig(f"{output_dir}/maps/county_{cc.analysis_file_key}_{map_index}_{code.string_value}.png",
-            #                 dpi=1200, bbox_inches="tight")
-            #     plt.close(fig)
-            #
-            #     map_index += 1
+            map_index = 2  # (index 1 was used in the total relevant map's filename).
+            for code in cc.code_scheme.codes:
+                if code.code_type != CodeTypes.NORMAL:
+                    continue
+
+                theme = f"{cc.analysis_file_key}{code.string_value}"
+                log.info(f"Generating a map of per-county participation for {theme}...")
+                demographic_counts = episode[theme]
+
+                theme_county_frequencies = dict()
+                for county_code in CodeSchemes.KENYA_COUNTY.codes:
+                    if county_code.code_type == CodeTypes.NORMAL:
+                        theme_county_frequencies[county_code.string_value] = \
+                            demographic_counts[f"county:{county_code.string_value}"]
+
+                fig, ax = plt.subplots()
+                MappingUtils.plot_frequency_map(counties_map, "ADM1_AVF", theme_county_frequencies, ax=ax,
+                                                label_position_columns=("ADM1_LX", "ADM1_LY"),
+                                                callout_position_columns=("ADM1_CALLX", "ADM1_CALLY"))
+                MappingUtils.plot_water_bodies(lakes_map, ax=ax)
+                fig.savefig(f"{output_dir}/maps/county_{cc.analysis_file_key}_{map_index}_{code.string_value}.png",
+                            dpi=1200, bbox_inches="tight")
+                plt.close(fig)
+
+                map_index += 1
 
     # Produce maps of Kenya at constituency level
     log.info("Loading the Kenya constituency geojson...")
@@ -488,33 +488,33 @@ if __name__ == "__main__":
             plt.close(fig)
 
             # Plot maps of each of the normal themes for this coding configuration.
-            # map_index = 2  # (index 1 was used in the total relevant map's filename).
-            # for code in cc.code_scheme.codes:
-            #     if code.code_type != CodeTypes.NORMAL:
-            #         continue
-            #
-            #     theme = f"{cc.analysis_file_key}{code.string_value}"
-            #     log.info(f"Generating a map of per-constituency participation for {theme}...")
-            #     demographic_counts = episode[theme]
-            #
-            #     theme_constituency_frequencies = dict()
-            #     for constituency_code in CodeSchemes.KENYA_CONSTITUENCY.codes:
-            #         if constituency_code.code_type == CodeTypes.NORMAL:
-            #             theme_constituency_frequencies[constituency_code.string_value] = \
-            #                 demographic_counts[f"constituency:{constituency_code.string_value}"]
-            #
-            #     fig, ax = plt.subplots()
-            #     MappingUtils.plot_frequency_map(constituencies_map, "ADM2_AVF", theme_constituency_frequencies, ax=ax)
-            #     MappingUtils.plot_inset_frequency_map(
-            #         constituencies_map, "ADM2_AVF", theme_constituency_frequencies,
-            #         inset_region=(36.62, -1.46, 37.12, -1.09), zoom=3, inset_position=(35.60, -2.95), ax=ax)
-            #     MappingUtils.plot_water_bodies(lakes_map, ax=ax)
-            #     plt.savefig(
-            #         f"{output_dir}/maps/constituency_{cc.analysis_file_key}_{map_index}_{code.string_value}.png",
-            #         dpi=1200, bbox_inches="tight")
-            #     plt.close(fig)
-            #
-            #     map_index += 1
+            map_index = 2  # (index 1 was used in the total relevant map's filename).
+            for code in cc.code_scheme.codes:
+                if code.code_type != CodeTypes.NORMAL:
+                    continue
+
+                theme = f"{cc.analysis_file_key}{code.string_value}"
+                log.info(f"Generating a map of per-constituency participation for {theme}...")
+                demographic_counts = episode[theme]
+
+                theme_constituency_frequencies = dict()
+                for constituency_code in CodeSchemes.KENYA_CONSTITUENCY.codes:
+                    if constituency_code.code_type == CodeTypes.NORMAL:
+                        theme_constituency_frequencies[constituency_code.string_value] = \
+                            demographic_counts[f"constituency:{constituency_code.string_value}"]
+
+                fig, ax = plt.subplots()
+                MappingUtils.plot_frequency_map(constituencies_map, "ADM2_AVF", theme_constituency_frequencies, ax=ax)
+                MappingUtils.plot_inset_frequency_map(
+                    constituencies_map, "ADM2_AVF", theme_constituency_frequencies,
+                    inset_region=(36.62, -1.46, 37.12, -1.09), zoom=3, inset_position=(35.60, -2.95), ax=ax)
+                MappingUtils.plot_water_bodies(lakes_map, ax=ax)
+                plt.savefig(
+                    f"{output_dir}/maps/constituency_{cc.analysis_file_key}_{map_index}_{code.string_value}.png",
+                    dpi=1200, bbox_inches="tight")
+                plt.close(fig)
+
+                map_index += 1
 
     # Produce maps of Nairobi/Kiambu at constituency level
     log.info("Loading the Kenya constituency geojson...")

--- a/automated_analysis.py
+++ b/automated_analysis.py
@@ -375,7 +375,7 @@ if __name__ == "__main__":
 
     log.info("Loading the Kenya constituency geojson...")
     constituencies_map = geopandas.read_file("geojson/kenya_constituencies.geojson")
-    nairobi_map = constituencies_map[constituencies_map.ADM1_AVF.isin({KenyaCodes.NAIROBI, KenyaCodes.KIAMBU})]
+    urban_map = constituencies_map[constituencies_map.ADM1_AVF.isin({KenyaCodes.NAIROBI, KenyaCodes.KIAMBU})]
     # Constituencies to label with their name, as requested by RDA for COVID19-KE-Urban
     constituencies_to_name_label = {
         # TODO: Switch to use KenyaCodes instead of strings
@@ -388,23 +388,23 @@ if __name__ == "__main__":
         constituency_display_names[admin_region.ADM2_AVF] = admin_region.ADM2_EN
 
     log.info("Generating a map of participation in Nairobi for the season")
-    nairobi_frequencies = dict()
+    urban_frequencies = dict()
     labels = dict()
     for code in CodeSchemes.KENYA_CONSTITUENCY.codes:
         if code.code_type == CodeTypes.NORMAL:
-            nairobi_frequencies[code.string_value] = demographic_distributions["constituency"][code.string_value]
+            urban_frequencies[code.string_value] = demographic_distributions["constituency"][code.string_value]
 
             if code.string_value in constituencies_to_name_label:
                 constituency_name = constituency_display_names[code.string_value]
-                labels[code.string_value] = constituency_name + "\n" + str(nairobi_frequencies[code.string_value])
+                labels[code.string_value] = constituency_name + "\n" + str(urban_frequencies[code.string_value])
             else:
-                labels[code.string_value] = str(nairobi_frequencies[code.string_value])
+                labels[code.string_value] = str(urban_frequencies[code.string_value])
 
     fig, ax = plt.subplots()
-    MappingUtils.plot_frequency_map(nairobi_map, "ADM2_AVF", nairobi_frequencies, ax=ax,
+    MappingUtils.plot_frequency_map(urban_map, "ADM2_AVF", urban_frequencies, ax=ax,
                                     labels=labels, label_position_columns=("ADM2_LX", "ADM2_LY"),
                                     callout_position_columns=("ADM2_CALLX", "ADM2_CALLY"))
-    fig.savefig(f"{output_dir}/maps/nairobi_total_participants.png", dpi=1200, bbox_inches="tight")
+    fig.savefig(f"{output_dir}/maps/urban_total_participants.png", dpi=1200, bbox_inches="tight")
     plt.close(fig)
 
     exit(0)

--- a/src/mapping_utils.py
+++ b/src/mapping_utils.py
@@ -27,6 +27,8 @@ class MappingUtils(object):
         :type admin_id_column: str
         :param frequencies: Dictionary of admin_id -> frequency.
         :type frequencies: dict of str -> int
+        :param labels: Dictionary of admin_id -> text to annotate the map with for each administrative region.
+        :type labels: dict of str -> str
         :param label_position_columns: A tuple specifying which columns in the `geo_data` contain the positions to draw
                                        each frequency label at, or None.
                                        The format is (X Position Column, Y Position Column). Positions should be in

--- a/src/mapping_utils.py
+++ b/src/mapping_utils.py
@@ -12,7 +12,7 @@ class MappingUtils(object):
     WATER_COLOR = "#edf5ff"
 
     @classmethod
-    def plot_frequency_map(cls, geo_data, admin_id_column, frequencies, label_position_columns=None,
+    def plot_frequency_map(cls, geo_data, admin_id_column, frequencies, labels=None, label_position_columns=None,
                            callout_position_columns=None, show_legend=True, ax=None):
         """
         Plots a map of the given geo data with a choropleth showing the frequency of responses in each administrative
@@ -89,7 +89,7 @@ class MappingUtils(object):
         # Add a label to each administrative region showing its absolute frequency.
         # The font size is currently hard-coded for Kenyan counties.
         # TODO: Modify once per-map configuration needs are better understood by testing on other maps.
-        if label_position_columns is not None:
+        if labels is not None:
             for i, admin_region in geo_data.iterrows():
                 # Set label and callout positions from the features in the geo_data,
                 # translating from the geo_data format to the matplotlib format.
@@ -102,7 +102,7 @@ class MappingUtils(object):
                     xy = (admin_region[callout_position_columns[0]], admin_region[callout_position_columns[1]])
                     xytext = (admin_region[label_position_columns[0]], admin_region[label_position_columns[1]])
 
-                ax.annotate(s=frequencies[admin_region[admin_id_column]],
+                ax.annotate(s=labels[admin_region[admin_id_column]],
                             xy=xy, xytext=xytext,
                             arrowprops=dict(facecolor="black", arrowstyle="-", linewidth=0.1, shrinkA=0, shrinkB=0),
                             ha="center", va="center", fontsize=3.8)


### PR DESCRIPTION
Sample outputs here: https://drive.google.com/open?id=1Wvh4oTMjHJu5pFOA1w-zCUcRDdHticfp.

Adds maps of Nairobi + Kiambu, with the constituencies of interest to RDA highlighted by showing their name as well as the total on the map. Doesn't add urban maps by theme, because these were not requested by RDA.

Updates to kenya_constituencies.geojson:
 - Adds ADM1_AVF ids.
 - Adds ADM2_LX and ADM2_LY, seeded with the co-ordinates from the ken_admbndp_admALL_iebc_itos_20191031.shp dataset from UN-OCHA. I'm not sure how these were determined - they give better results than automated methods I've tried, but still aren't quite as good as manual judgement. The co-ordinates for the constituencies shown here were therefore refined slightly in QGIS - points for other constituencies will need to be adjusted as needed.
 - Adds ADM2_CALLX and ADM2_CALLY co-ordinates which make sense for the urban map. I think in future we'll need to specify these somewhere else and determine placement automatically, because the best location for callouts depends on the subset of the constituency data being displayed.
