### PR TITLE
Re-enable e06 support for Ghetto

### DIFF
--- a/configuration/pipeline_config.json
+++ b/configuration/pipeline_config.json
@@ -33,7 +33,8 @@
         "covid19_ke_urban_s01e02_activation",
         "covid19_ke_urban_s01e03_activation",
         "covid19_ke_urban_s01e04_activation",
-        "covid19_ke_urban_s01e05_activation"
+        "covid19_ke_urban_s01e05_activation",
+        "covid19_ke_urban_s01e06_activation"
       ],
       "SurveyFlowNames": [
         "covid19_ke_urban_s01_demog"
@@ -74,6 +75,10 @@
     {"RapidProKey": "Rqa_S01E05 (Text) - covid19_ke_urban_s01e05_activation", "PipelineKey": "rqa_s01e05_raw", "IsActivationMessage": true},
     {"RapidProKey": "Rqa_S01E05 (Run ID) - covid19_ke_urban_s01e05_activation", "PipelineKey": "rqa_s01e05_run_id"},
     {"RapidProKey": "Rqa_S01E05 (Time) - covid19_ke_urban_s01e05_activation", "PipelineKey": "sent_on"},
+    
+    {"RapidProKey": "Rqa_S01E06 (Text) - covid19_ke_urban_s01e06_activation", "PipelineKey": "rqa_s01e06_raw", "IsActivationMessage": true},
+    {"RapidProKey": "Rqa_S01E06 (Run ID) - covid19_ke_urban_s01e06_activation", "PipelineKey": "rqa_s01e06_run_id"},
+    {"RapidProKey": "Rqa_S01E06 (Time) - covid19_ke_urban_s01e06_activation", "PipelineKey": "sent_on"},
 
     {"RapidProKey": "Rqa_S01E02 (Text) - covid19_s01e03_activation", "PipelineKey": "rqa_s01e03_raw", "IsActivationMessage": true},
     {"RapidProKey": "Rqa_S01E02 (Run ID) - covid19_s01e03_activation", "PipelineKey": "rqa_s01e03_run_id"},


### PR DESCRIPTION
We removed this because we're not having a radio show next week. However, we've since decided to run the question by sms only until we can resume on-air discussions again in an attempt to keep the conversation going, so adding it back.

We only need to update the configuration file because jambo was going ahead with e06 anyway, so the rest of the e06 configuration was still in the pipeline.