### PR TITLE
Automatically create folders on Drive when uploading

### DIFF
--- a/automated_analysis.py
+++ b/automated_analysis.py
@@ -680,7 +680,8 @@ if __name__ == "__main__":
         for i, path in enumerate(paths_to_upload):
             log.info(f"Uploading CSV {i + 1}/{len(paths_to_upload)}: {path}...")
             drive_client_wrapper.update_or_create(
-                path, pipeline_configuration.drive_upload.analysis_graphs_dir, target_folder_is_shared_with_me=True
+                path, pipeline_configuration.drive_upload.analysis_graphs_dir, target_folder_is_shared_with_me=True,
+                recursive=True
             )
 
         log.info("Uploading graphs to Drive...")
@@ -689,7 +690,7 @@ if __name__ == "__main__":
             log.info(f"Uploading graph {i + 1}/{len(paths_to_upload)}: {path}...")
             drive_client_wrapper.update_or_create(
                 path, f"{pipeline_configuration.drive_upload.analysis_graphs_dir}/graphs",
-                target_folder_is_shared_with_me=True
+                target_folder_is_shared_with_me=True, recursive=True
             )
 
         log.info("Uploading county maps to Drive...")
@@ -698,7 +699,7 @@ if __name__ == "__main__":
             log.info(f"Uploading county map {i + 1}/{len(paths_to_upload)}: {path}...")
             drive_client_wrapper.update_or_create(
                 path, f"{pipeline_configuration.drive_upload.analysis_graphs_dir}/maps/counties",
-                target_folder_is_shared_with_me=True
+                target_folder_is_shared_with_me=True, recursive=True
             )
 
         log.info("Uploading constituency maps to Drive...")
@@ -707,7 +708,7 @@ if __name__ == "__main__":
             log.info(f"Uploading constituency map {i + 1}/{len(paths_to_upload)}: {path}...")
             drive_client_wrapper.update_or_create(
                 path, f"{pipeline_configuration.drive_upload.analysis_graphs_dir}/maps/constituencies",
-                target_folder_is_shared_with_me=True
+                target_folder_is_shared_with_me=True, recursive=True
             )
 
         log.info("Uploading urban maps to Drive...")
@@ -716,7 +717,7 @@ if __name__ == "__main__":
             log.info(f"Uploading urban map {i + 1}/{len(paths_to_upload)}: {path}...")
             drive_client_wrapper.update_or_create(
                 path, f"{pipeline_configuration.drive_upload.analysis_graphs_dir}/maps/urban",
-                target_folder_is_shared_with_me=True
+                target_folder_is_shared_with_me=True, recursive=True
             )
     else:
         log.info("Skipping uploading to Google Drive (because the pipeline configuration json does not contain the key "

--- a/upload_files.py
+++ b/upload_files.py
@@ -66,19 +66,19 @@ if __name__ == "__main__":
         production_csv_drive_file_name = os.path.basename(pipeline_configuration.drive_upload.production_upload_path)
         drive_client_wrapper.update_or_create(production_csv_input_path, production_csv_drive_dir,
                                               target_file_name=production_csv_drive_file_name,
-                                              target_folder_is_shared_with_me=True)
+                                              target_folder_is_shared_with_me=True, recursive=True)
 
         messages_csv_drive_dir = os.path.dirname(pipeline_configuration.drive_upload.messages_upload_path)
         messages_csv_drive_file_name = os.path.basename(pipeline_configuration.drive_upload.messages_upload_path)
         drive_client_wrapper.update_or_create(messages_csv_input_path, messages_csv_drive_dir,
                                               target_file_name=messages_csv_drive_file_name,
-                                              target_folder_is_shared_with_me=True)
+                                              target_folder_is_shared_with_me=True, recursive=True)
 
         individuals_csv_drive_dir = os.path.dirname(pipeline_configuration.drive_upload.individuals_upload_path)
         individuals_csv_drive_file_name = os.path.basename(pipeline_configuration.drive_upload.individuals_upload_path)
         drive_client_wrapper.update_or_create(individuals_csv_input_path, individuals_csv_drive_dir,
                                               target_file_name=individuals_csv_drive_file_name,
-                                              target_folder_is_shared_with_me=True)
+                                              target_folder_is_shared_with_me=True, recursive=True)
     else:
         log.info("Skipping uploading to Google Drive (because the pipeline configuration json does not contain the key "
                  "'DriveUploadPaths')")


### PR DESCRIPTION
I discovered this when poking around the existing internals of Pipeline-Infrastructure. Doesn't bring immediate benefit to us now, but will save us some time when setting up future pipelines because we'll no longer need to remember to create all those subdirectories.