### PR TITLE
Fix performance bug when computing theme distributions.

### DIFF
--- a/automated_analysis.py
+++ b/automated_analysis.py
@@ -325,17 +325,17 @@ if __name__ == "__main__":
                 themes["Total Relevant Participants"]["Total Participants"] += 1
                 update_survey_counts(themes["Total Relevant Participants"], td)
 
-            set_survey_percentages(themes["Total Relevant Participants"], themes["Total Relevant Participants"])
+        set_survey_percentages(themes["Total Relevant Participants"], themes["Total Relevant Participants"])
 
-            for cc in episode_plan.coding_configurations:
-                assert cc.coding_mode == CodingModes.MULTIPLE, "Other CodingModes not (yet) supported"
+        for cc in episode_plan.coding_configurations:
+            assert cc.coding_mode == CodingModes.MULTIPLE, "Other CodingModes not (yet) supported"
 
-                for code in cc.code_scheme.codes:
-                    if code.code_type != CodeTypes.NORMAL:
-                        continue
+            for code in cc.code_scheme.codes:
+                if code.code_type != CodeTypes.NORMAL:
+                    continue
 
-                    theme = themes[f"{cc.analysis_file_key}{code.string_value}"]
-                    set_survey_percentages(theme, themes["Total Relevant Participants"])
+                theme = themes[f"{cc.analysis_file_key}{code.string_value}"]
+                set_survey_percentages(theme, themes["Total Relevant Participants"])
 
     with open(f"{output_dir}/theme_distributions.csv", "w") as f:
         headers = ["Question", "Variable"] + list(make_survey_counts_dict().keys())


### PR DESCRIPTION
Fixes by resolving an indentation error which was causing survey percentages to be recomputed for every individual rather than just once at the end. Testing on a subset of the data, this reduces the computation time from ~2m to <1s.